### PR TITLE
remove unnecessary second layer of hooks

### DIFF
--- a/classic-editor-addon.php
+++ b/classic-editor-addon.php
@@ -26,14 +26,9 @@
 // don't load the plugin file directly
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-add_action( 'plugins_loaded', 'classic_editor_addon_init', 1, 0 );
+add_action( 'plugins_loaded', 'classic_editor_addon_pre_init', 1, 0 );
 
-function classic_editor_addon_init() {
-	/**
-	 * Remove the Try Gutenberg Panel, slated for WordPress 4.9.8
-	 */
-	remove_action( 'try_gutenberg_panel', 'wp_try_gutenberg_panel' );
-
+function classic_editor_addon_pre_init() {
 	if ( function_exists( 'classic_editor_init_actions' ) ) {
 		/**
 		 * Change the default option of "no-replace" to "replace",
@@ -41,28 +36,28 @@ function classic_editor_addon_init() {
 		 * does what it says from the get-go (L336).
 		 */
 		add_filter( 'pre_option_classic-editor-replace', 'classic_editor_addon_hardcode_replace' );
+	}
 
+}
+
+add_action( 'plugins_loaded', 'classic_editor_addon_post_init', 20, 0 );
+
+function classic_editor_addon_post_init() {
+	/**
+	 * Remove the Try Gutenberg Panel, slated for WordPress 4.9.8
+	 */
+	remove_action( 'try_gutenberg_panel', 'wp_try_gutenberg_panel' );
+
+	if ( function_exists( 'classic_editor_init_actions' ) ) {
 		/**
 		 * Remove Settings link to the settings from the Plugins screen (L277).
 		 */
-		add_action( 'plugins_loaded', 'classic_editor_addon_remove_settings_link' );
-
-		/**
-		 * Hide the Settings of the plugin on the Settings > Writing screen
-		 */
-		add_action( 'admin_footer', 'classic_editor_hide_settings' );
+		remove_filter( 'plugin_action_links', 'classic_editor_add_settings_link' );
+		remove_action( 'admin_init', 'classic_editor_admin_init' );
 	}
 
 }
 
 function classic_editor_addon_hardcode_replace( $value ) {
 	return 'replace';
-}
-
-function classic_editor_addon_remove_settings_link() {
-	remove_filter( 'plugin_action_links', 'classic_editor_add_settings_link' );
-}
-
-function classic_editor_hide_settings() {
-	echo '<style>#classic-editor-options{display:none;}</style>';
 }


### PR DESCRIPTION
Fully remove the settings page, rather than just hiding it, and flatten the nested call to plugins_loaded for clarity